### PR TITLE
Implement team invite join feature

### DIFF
--- a/Server/repositories/user_team_repository.go
+++ b/Server/repositories/user_team_repository.go
@@ -9,6 +9,7 @@ import (
 
 type UserTeamRepository interface {
 	AddTeamAdmin(tx *gorm.DB, userId string, team *models.Team) error
+	AddTeamMember(tx *gorm.DB, userId string, team *models.Team) error
 	GetByUserIdAndTeamId(tx *gorm.DB, userId string, teamId string) (*models.UserTeam, error)
 	FindByUserIdAndTeamId(tx *gorm.DB, userId string, teamId string) (*models.UserTeam, error)
 }
@@ -31,6 +32,19 @@ func (r *userTeamRepository) AddTeamAdmin(tx *gorm.DB, userId string, team *mode
 		return err
 	}
 
+	return nil
+}
+
+// チームメンバーとしてユーザーを追加する
+func (r *userTeamRepository) AddTeamMember(tx *gorm.DB, userId string, team *models.Team) error {
+	userTeam := models.UserTeam{
+		UserID: userId,
+		TeamID: team.ID,
+		Role:   models.TeamMember,
+	}
+	if err := tx.Create(&userTeam).Error; err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/Server/server/router.go
+++ b/Server/server/router.go
@@ -46,6 +46,7 @@ func NewRouter() (*gin.Engine, error) {
 		router.GET("/opponent_recruitings", opponentRecruitingController.Index())
 		router.GET("/opponent_recruitings/:opponent_recruiting_id", opponentRecruitingController.Get())
 		router.GET("/teams/:team_id", teamController.Get())
+		router.GET("/teams/invite/:invite_token", teamController.GetByInviteToken())
 		router.POST("/login", userController.Login())
 	}
 
@@ -59,6 +60,7 @@ func NewRouter() (*gin.Engine, error) {
 		authRequired.POST("/teams", teamController.Create())
 		authRequired.PATCH("/teams/:team_id", teamController.Update())
 		authRequired.POST("/teams/:team_id/invite_token", teamController.CreateInviteToken())
+		authRequired.POST("/teams/invite/:invite_token", teamController.JoinByInviteToken())
 		authRequired.POST("/opponent_recruitings", opponentRecruitingController.Create())
 		authRequired.PATCH("/opponent_recruitings/:opponent_recruiting_id", opponentRecruitingController.Update())
 		authRequired.PATCH("/opponent_recruitings/:opponent_recruiting_id/status", opponentRecruitingController.ChangeStatus())

--- a/Server/services/team_service.go
+++ b/Server/services/team_service.go
@@ -5,6 +5,7 @@ import (
 	"react_go_otasuke_app/models"
 	"react_go_otasuke_app/repositories"
 	"react_go_otasuke_app/utils"
+	"time"
 
 	"gorm.io/gorm"
 )
@@ -14,21 +15,23 @@ type TeamService interface {
 	CreateTeamWithAdmin(tx *gorm.DB, userId string, team *models.Team) error
 	UpdateTeam(tx *gorm.DB, userId string, teamId string, team *models.Team) error
 	CreateInviteToken(tx *gorm.DB, userId string, team *models.Team) (*models.TeamInvite, error)
+	GetTeamByInviteToken(tx *gorm.DB, token string) (*models.Team, error)
+	JoinTeamByInviteToken(tx *gorm.DB, userId string, token string) (*models.Team, error)
 }
 
 type teamService struct {
-	userTeamService    UserTeamService
-	teamRepository     repositories.TeamRepository
-	userTeamRepository repositories.UserTeamRepository
+	userTeamService      UserTeamService
+	teamRepository       repositories.TeamRepository
+	userTeamRepository   repositories.UserTeamRepository
 	teamInviteRepository repositories.TeamInviteRepository
 }
 
 // チームサービスを作成する
 func NewTeamService(uts UserTeamService, teamRepo repositories.TeamRepository, userTeamRepo repositories.UserTeamRepository, teamInviteRepo repositories.TeamInviteRepository) TeamService {
 	return &teamService{
-		userTeamService:    uts,
-		teamRepository:     teamRepo,
-		userTeamRepository: userTeamRepo,
+		userTeamService:      uts,
+		teamRepository:       teamRepo,
+		userTeamRepository:   userTeamRepo,
 		teamInviteRepository: teamInviteRepo,
 	}
 }
@@ -51,14 +54,14 @@ func (ts *teamService) CreateTeamWithAdmin(tx *gorm.DB, userId string, team *mod
 	for attempt := 1; attempt <= 3; attempt++ {
 		// チームを作成する
 		if err = ts.teamRepository.Create(tx, team); err != nil {
-			continue;
+			continue
 		}
 		isTeamCreated = true
 		break
 	}
 
 	// チーム作成できなかった場合
-	if(!isTeamCreated){
+	if !isTeamCreated {
 		return err
 	}
 
@@ -86,10 +89,44 @@ func (ts *teamService) CreateInviteToken(tx *gorm.DB, userId string, team *model
 	if !ts.userTeamService.IsAdminOrSubAdmin(tx, userId, team.ID) {
 		return nil, errors.New("管理者または副管理者のみ招待トークンを発行できます")
 	}
-	
+
 	// トークンを生成する
 	token, _ := utils.GenerateRandomString(30)
 
 	// 招待トークンを作成する
 	return ts.teamInviteRepository.CreateOrUpdateInvite(tx, team.ID, token)
+}
+
+func (ts *teamService) GetTeamByInviteToken(tx *gorm.DB, token string) (*models.Team, error) {
+	invite, err := ts.teamInviteRepository.GetByToken(tx, token)
+	if err != nil {
+		return nil, err
+	}
+	if invite == nil || invite.ExpiresAt.Before(time.Now()) {
+		return nil, errors.New("招待URLが無効です")
+	}
+
+	return ts.teamRepository.GetById(tx, invite.TeamID)
+}
+
+func (ts *teamService) JoinTeamByInviteToken(tx *gorm.DB, userId string, token string) (*models.Team, error) {
+	team, err := ts.GetTeamByInviteToken(tx, token)
+	if err != nil || team == nil {
+		return nil, err
+	}
+
+	// すでに所属しているか確認
+	userTeam, err := ts.userTeamRepository.GetByUserIdAndTeamId(tx, userId, team.ID)
+	if err != nil {
+		return nil, err
+	}
+	if userTeam != nil {
+		return nil, errors.New("既にチームに所属しています")
+	}
+
+	if err := ts.userTeamRepository.AddTeamMember(tx, userId, team); err != nil {
+		return nil, err
+	}
+
+	return team, nil
 }


### PR DESCRIPTION
## Summary
- support retrieving a team via invite token
- allow authenticated users to join a team with an invite token
- expose new invite routes

## Testing
- `go vet ./...` *(fails: Forbidden)*
- `go build ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68483a1b576c8333ae3e17ec05b4f485